### PR TITLE
bug - Fix timezone issues with container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 
 FROM python:3.14
 
+ENV TZ=America/Vancouver
 
 WORKDIR /code
 


### PR DESCRIPTION
Added timeszone setting to docker setup for proper time when validating restaurants are open or closed as current did not match timezone and was causing errors